### PR TITLE
Fix Jackson serialization error on first console login

### DIFF
--- a/org.jgrapes.webconsole.base/src/org/jgrapes/webconsole/base/KVStoreBasedConsolePolicy.java
+++ b/org.jgrapes.webconsole.base/src/org/jgrapes/webconsole/base/KVStoreBasedConsolePolicy.java
@@ -214,7 +214,7 @@ public class KVStoreBasedConsolePolicy extends Component {
             List<String> tabsLayout = (List<String>) persisted.computeIfAbsent(
                 "tabsLayout", newKey -> Collections.emptyList());
             Object xtraInfo = persisted.computeIfAbsent(
-                "xtraInfo", newKey -> new Object());
+                "xtraInfo", newKey -> new HashMap<>());
 
             // Update (now consistent) layout
             channel.respond(new LastConsoleLayout(


### PR DESCRIPTION
Fixes https://github.com/mnlipp/VM-Operator/issues/35

On first login (no persisted layout data), xtraInfo defaulted to `new Object()` which has no properties, causing Jackson FAIL_ON_EMPTY_BEANS. Changed the default to `new HashMap<>()` so it serializes to an empty JSON object.